### PR TITLE
在实际项目中使用后，修复的一系列bug

### DIFF
--- a/src/main/java/io/gitlab/leibnizhu/sbnetty/core/NettyContainer.java
+++ b/src/main/java/io/gitlab/leibnizhu/sbnetty/core/NettyContainer.java
@@ -10,6 +10,7 @@ import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.codec.http.HttpServerCodec;
+import io.netty.handler.stream.ChunkedWriteHandler;
 import io.netty.util.concurrent.DefaultEventExecutorGroup;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -72,6 +73,7 @@ public class NettyContainer implements EmbeddedServletContainer {
             protected void initChannel(SocketChannel ch) throws Exception {
                 ChannelPipeline p = ch.pipeline();
                 p.addLast("codec", new HttpServerCodec(4096, 8192, 8192, false)); //HTTP编码解码Handler
+                p.addLast("chunked", new ChunkedWriteHandler());
                 p.addLast("servletInput", new ServletContentHandler(servletContext)); //处理请求，读入数据，生成Request和Response对象
                 p.addLast(checkNotNull(servletExecutor), "filterChain", new RequestDispatcherHandler(servletContext)); //获取请求分发器，让对应的Servlet处理请求，同时处理404情况
             }

--- a/src/main/java/io/gitlab/leibnizhu/sbnetty/core/NettyContext.java
+++ b/src/main/java/io/gitlab/leibnizhu/sbnetty/core/NettyContext.java
@@ -192,7 +192,7 @@ public class NettyContext implements ServletContext {
         }*/
         Servlet servlet;
         try {
-            servlet = null == servletName ? null : servlets.get(servletName).getServlet();
+            servlet = null == servletName ? null : servlets.get(servletName).getServlet(true);
             if (servlet == null) {
                 return null;
             }
@@ -202,7 +202,7 @@ public class NettyContext implements ServletContext {
                 allNeedFilters.add(registration.getFilter());
             }
             FilterChain filterChain = new NettyFilterChain(servlet, allNeedFilters);
-            return new NettyRequestDispatcher(this, filterChain);
+            return new NettyRequestDispatcher( filterChain,path);
         } catch (ServletException e) {
             log.error("Throwing exception when getting Filter from NettyFilterRegistration of path " + path, e);
             return null;
@@ -216,7 +216,7 @@ public class NettyContext implements ServletContext {
 
     @Override
     public Servlet getServlet(String name) throws ServletException {
-        return servlets.get(name).getServlet();
+        return servlets.get(name).getServlet(true);
     }
 
     @Override

--- a/src/main/java/io/gitlab/leibnizhu/sbnetty/core/NettyRequestDispatcher.java
+++ b/src/main/java/io/gitlab/leibnizhu/sbnetty/core/NettyRequestDispatcher.java
@@ -3,24 +3,31 @@ package io.gitlab.leibnizhu.sbnetty.core;
 import io.gitlab.leibnizhu.sbnetty.request.NettyHttpServletRequest;
 
 import javax.servlet.*;
+import javax.servlet.http.HttpServletRequestWrapper;
 import java.io.IOException;
 
 /**
  * 分发器，除了传统的forward和include，把正常的Servlet调用也放在这里dispatch()方法
  */
 public class NettyRequestDispatcher implements RequestDispatcher {
-    private final ServletContext context;
     private final FilterChain filterChain;
+    private final String path;
 
-    NettyRequestDispatcher(ServletContext context, FilterChain filterChain) {
-        this.context = context;
+    NettyRequestDispatcher(FilterChain filterChain, String path) {
         this.filterChain = filterChain;
+        this.path = path;
     }
 
     @Override
     public void forward(ServletRequest request, ServletResponse response) throws ServletException, IOException {
         request.setAttribute(NettyHttpServletRequest.DISPATCHER_TYPE, DispatcherType.FORWARD);
-        // TODO implement
+        NettyHttpServletRequest servletRequest = (NettyHttpServletRequest) request;
+        filterChain.doFilter(new HttpServletRequestWrapper(servletRequest) {
+            @Override
+            public String getRequestURI() {
+                return path;
+            }
+        }, response);
     }
 
     @Override


### PR DESCRIPTION
1. 后置调用Servlet.init()，避免spring容器启动可能存在循环依赖
2. 实现servlet的getRequestURL，此方法导致swagger的内部servlet服务空指针无法服务
3. servlet解析Date类型的header时，和nettyAPI接口相似但行为不一致
4. HttpServletResponse在多段write时，outputStream被提前commit，导致http返回数据不完整
5. 简单支持了forward，这是因为静态资源服务器访问根目录是，springboot要求forward到index.html